### PR TITLE
Use Non-Deprecated Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,14 +252,14 @@ Enzyme is similar, but builds on jsdom and makes it easier to make certain queri
 Let's install it as a development-time dependency.
 
 ```sh
-npm install -D enzyme @types/enzyme react-addons-test-utils
+npm install -D enzyme @types/enzyme react-test-renderer
 ```
 
 Notice we installed packages `enzyme` as well as `@types/enzyme`.
 The `enzyme` package refers to the package containing JavaScript code that actually gets run, while `@types/enzyme` is a package that contains declaration files (`.d.ts` files) so that TypeScript can understand how you can use Enzyme.
 You can learn more about `@types` packages [here](https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html).
 
-We also had to install `react-addons-test-utils`.
+We also had to install `react-test-renderer`.
 This is something `enzyme` expects to be installed.
 
 Now that we've got Enzyme set up, let's start writing our test!


### PR DESCRIPTION
The react-addons-test-utils package has been deprecated in favor of react-test-renderer.
The enzyme installation documentation now requires react-test-renderer to be installed for React >=15.5.
I was getting an error when trying to use react-addons-test-utils. (Sorry I don't have the error documented.)
As of this PR, React is at version 15.6.1.

And thanks again Daniel for a great tutorial! Much, much appreciated!